### PR TITLE
fix: bugs caused when authors data file is not defined

### DIFF
--- a/lib/jekyll-auto-authors/authorAutoPage.rb
+++ b/lib/jekyll-auto-authors/authorAutoPage.rb
@@ -12,14 +12,17 @@ module Jekyll
         set_autopage_data_lambda = lambda do | in_config |
           in_config["author"] = author
 
-          if autopage_config["data"].nil?
-            return
-          end
+          return if autopage_config["data"].nil?
 
-          # if a data file containing authors is not nil, transfer it to paginator object
-          # so that it can be used in the pagination template
-          author_data = YAML::load(File.read(autopage_config["data"]))
-          in_config["author_data"] = author_data[author_name]
+          # if the data file containing authors info is not nil, transfer current author's data
+          # to the paginator object so that it can be used in the pagination template
+          author_data = YAML::load(File.read(autopage_config["data"])) || {}
+
+          if author_data.key?(author_name)
+            in_config["author_data"] = author_data[author_name]
+          else
+            Jekyll.logger.warn "Author Pages:", "Data for author '#{author_name}' not found. Page will be generated without data."
+          end
         end
 
         # Lambdas to return formatted permalink and title.

--- a/lib/jekyll-auto-authors/defaults.rb
+++ b/lib/jekyll-auto-authors/defaults.rb
@@ -5,7 +5,7 @@ module Jekyll
     DEFAULT = {
       "enabled" => false, # Enable or disable the plugin.
 
-      "data" => "_data/authors.yml", # The data file inside _data/ folder that contains author information.
+      "data" => nil, # The path to file that contains authors information. example: "_data/authors.yml"
       "layouts" => ["authors.html"], # The layout file inside _layouts/ folder to use for the author pages.
 
       "exclude" => [], # The list of authors to **force** skip processing an autopage for.


### PR DESCRIPTION
The plugin allows skipping defining the data file but doing so introduces bugs because parts of the code expect that file to be present. This PR fixes that without affecting generation logic.